### PR TITLE
deps: fix dependabot vulns (swiper critical, postcss)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "posthog-js": "^1.116.6",
-        "swiper": "^10.3.1"
+        "swiper": "^14.0.1"
       },
       "devDependencies": {
         "vitepress": "^1.6.4"
@@ -2000,9 +2000,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -2045,9 +2045,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -2065,7 +2065,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2266,19 +2266,20 @@
       }
     },
     "node_modules/swiper": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
-      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-14.0.1.tgz",
+      "integrity": "sha512-dibQY282S5rn6S9Ba+GTIvofyY4Qujy526a0cPaJnjR2S18Z7HMGKZBr8k/3ukboeKW/ig5h0q//7CYip0MCQw==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "dependencies": {
     "posthog-js": "^1.116.6",
-    "swiper": "^10.3.1"
+    "swiper": "^14.0.1"
   }
 }


### PR DESCRIPTION
## What

Clears the actionable Dependabot advisories:

- **swiper** `^10.3.1` → `^14.0.1` — fixes [GHSA-hmx5-qpq5-p643](https://github.com/advisories/GHSA-hmx5-qpq5-p643) prototype pollution (**critical**)
- **postcss** `8.5.8` → `8.5.16` — fixes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) XSS (moderate)

## Why the swiper major bump is safe

`components/Images.vue` uses the modern `swiper/vue` + `swiper/modules` API (slot-based `<swiper>`/`<swiper-slide>`, `:zoom`/`:pagination`/`:navigation`, `Zoom`/`Pagination`/`Navigation` modules). That API is unchanged across v10→v14. `npm run docs:build` passes — all `swiper/css/*` and `swiper/modules` subpath imports resolve under v14 and the component SSR-renders without error.

⚠️ Worth a quick visual check of the image carousel (zoom + pagination + nav arrows) after merge, since runtime interactivity can't be verified from a build alone.

## Knowingly left alone

The remaining `esbuild`/`vite` advisories (2 moderate, 1 high) are **transitive under `vitepress` and dev-server-only** — they affect `vitepress dev` on a local machine, not the built static site or production. Clearing them requires a `vitepress` major upgrade, which is a larger change tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)